### PR TITLE
PyOpenSci REVIEW - minor updates

### DIFF
--- a/pynteny/__init__.py
+++ b/pynteny/__init__.py
@@ -1,2 +1,2 @@
-from pynteny.api import *
+from pynteny.api import Command, Search, Build, Download
 from pynteny.cli import main

--- a/pynteny/api.py
+++ b/pynteny/api.py
@@ -24,10 +24,11 @@ __author__ = meta["Author"]
 
 
 class Command:
-    """Parent class for Pynteny command"""
+    """
+    Parent class for Pynteny command
 
-    def __init__(self):
-        """Parent class for Pynteny command"""
+    args: CommandArgs
+    """
 
     def _repr_html_(self):
         """Executed by Jupyter to print Author and version in html"""

--- a/pynteny/app/helpers.py
+++ b/pynteny/app/helpers.py
@@ -12,7 +12,7 @@ from pynteny.subcommands import synteny_search, build_database, download_hmms
 from pynteny.utils import ConfigParser
 
 
-parent_dir = Path(Path(__file__).parent)
+parent_dir = Path(__file__).parent
 
 
 class FileManager:

--- a/pynteny/app/main_page.py
+++ b/pynteny/app/main_page.py
@@ -9,7 +9,7 @@ from pynteny.app.helpers import ExampleSearch
 from pynteny.app.components import Sidebar, Mainpage
 
 
-parent_dir = Path(Path(__file__).parent)
+parent_dir = Path(__file__).parent
 meta = metadata.metadata("pynteny")
 __version__ = meta["Version"]
 __author__ = meta["Author"]

--- a/pynteny/cli.py
+++ b/pynteny/cli.py
@@ -458,7 +458,7 @@ class SubcommandParser:
         )
 
         optional = parser._action_groups.pop()
-        required = parser.add_argument_group("required arguments")
+        # required = parser.add_argument_group("required arguments")
         parser._action_groups.append(optional)
 
         optional.add_argument(

--- a/pynteny/cli.py
+++ b/pynteny/cli.py
@@ -89,7 +89,7 @@ class Pynteny:
             "One does not simply walk into Mordor (J.R.R. Tolkien)",
             "Damn, looks like a rainy day, let's do bioiformatics! (SR)",
         ]
-        return f"{random.choice(quotes)}\n" " "
+        return f"{random.choice(quotes)}\n"
 
     def _call_subcommand(self, subcommand_name: str) -> None:
         subcommand = getattr(self, subcommand_name)
@@ -182,16 +182,16 @@ class SubcommandParser:
             type=str,
             required=True,
             help=(
-                f"string displaying hmm structure to search for, such as: \n"
-                f" \n"
-                f"'>hmm_a n_ab <hmm_b n_bc hmm_c'\n"
-                f" \n"
-                f"where '>' indicates a hmm target located on the positive strand, \n"
-                f"'<' a target located on the negative strand, and n_ab cooresponds \n"
-                f"to the maximum number of genes separating matched genes a and b. \n"
-                f"Multiple hmms may be employed. \n"
-                f"No order symbol in a hmm indicates that results should be independent \n"
-                f"of strand location. "
+                "string displaying hmm structure to search for, such as: \n"
+                " \n"
+                "'>hmm_a n_ab <hmm_b n_bc hmm_c'\n"
+                " \n"
+                "where '>' indicates a hmm target located on the positive strand, \n"
+                "'<' a target located on the negative strand, and n_ab cooresponds \n"
+                "to the maximum number of genes separating matched genes a and b. \n"
+                "Multiple hmms may be employed. \n"
+                "No order symbol in a hmm indicates that results should be independent \n"
+                "of strand location. "
             ),
         )
         required.add_argument(

--- a/pynteny/parser.py
+++ b/pynteny/parser.py
@@ -39,21 +39,26 @@ class LabelParser:
             "locus_pos": None,
             "strand": "",
         }
-        try:
-            entry = label.split("__")[0]
-            meta = label.split("__")[1]
-            strand = meta.split("_")[-1]
-            locus_pos = tuple([int(pos) for pos in meta.split("_")[-3:-1]])
-            gene_pos = int(meta.split("_")[-4])
-            contig = "_".join(meta.split("_")[:-4])
 
-            parsed_dict["gene_id"] = entry
-            parsed_dict["contig"] = contig
-            parsed_dict["gene_pos"] = gene_pos
-            parsed_dict["locus_pos"] = locus_pos
-            parsed_dict["strand"] = strand
-        except Exception:
-            pass
+        if label.count("__") > 1:
+            logger.error("Invalid format of record label string")
+            sys.exit(1)
+
+        entry = label.split("__")[0]
+        meta = label.split("__")[1]
+        meta_items = meta.split("_")
+
+        strand = meta_items[-1]
+        locus_pos = tuple([int(pos) for pos in meta_items[-3:-1]])
+        gene_pos = int(meta_items[-4])
+        contig = "_".join(meta_items[:-4])
+
+        parsed_dict["gene_id"] = entry
+        parsed_dict["contig"] = contig
+        parsed_dict["gene_pos"] = gene_pos
+        parsed_dict["locus_pos"] = locus_pos
+        parsed_dict["strand"] = strand
+
         return parsed_dict
 
     @staticmethod
@@ -107,7 +112,7 @@ class SyntenyParser:
     @staticmethod
     def split_strand_from_locus(
         locus_str: str, parsed_symbol: bool = True
-    ) -> tuple[str]:
+    ) -> tuple[str, ...]:
         """Split strand info from locus tag / HMM model.
 
         Args:
@@ -117,7 +122,7 @@ class SyntenyParser:
                 as 'pos' and '<' as 'neg'. Defaults to True.
 
         Returns:
-            tuple[str]: tuple with parsed strand info and gene symbol / HMM name.
+            tuple[str, ...]: tuple with parsed strand info and gene symbol / HMM name.
         """
         locus_str = locus_str.strip()
         if locus_str[0] == "<" or locus_str[0] == ">":

--- a/pynteny/preprocessing.py
+++ b/pynteny/preprocessing.py
@@ -428,6 +428,27 @@ class LabelledFASTA(FASTA):
                         )
         return cls(output_file)
 
+    def get_label_str(self, gbk_contig, feature, gene_counter):
+        name = feature.qualifiers["locus_tag"][0].replace("_", ".")
+        start, end, strand = (
+            str(feature.location.start),
+            str(feature.location.end),
+            feature.location.strand,
+        )
+        start = start.replace(">", "").replace("<", "")
+        end = end.replace(">", "").replace("<", "")
+        strand_sense = "neg" if strand == -1 else ("pos" if strand == 1 else "")
+        return f">{name}__{gbk_contig.name.replace('_', '')}_{gene_counter}_{start}_{end}_{strand_sense}\n"
+
+    def write_record(self, gbk_contig, feature, outfile, gene_counter):
+        if "translation" in feature.qualifiers:
+            header = self.get_label_str(gbk_contig, feature)
+            sequence = feature.qualifiers["translation"][0]
+            outfile.write(header)
+            outfile.write(sequence + "\n")
+            gene_counter += 1
+        return gene_counter
+
 
 class GeneAnnotator:
     """Run prodigal on assembly, predict ORFs and extract location info"""

--- a/pynteny/preprocessing.py
+++ b/pynteny/preprocessing.py
@@ -10,13 +10,14 @@ Tools to preprocess sequence databases
 """
 
 from __future__ import annotations
+from typing import TextIO
 import sys
 import os
 import logging
 import tempfile
 from pathlib import Path
 
-from Bio import SeqIO
+from Bio import SeqIO, SeqRecord, SeqFeature
 import pyfastx
 
 import pynteny.utils as utils
@@ -385,50 +386,20 @@ class LabelledFASTA(FASTA):
                 Path(gbk_files.pop().parent) / f"{prefix}sequence_database.fasta"
             )
 
-        def get_label_str(gbk_contig, feature):
-            name = feature.qualifiers["locus_tag"][0].replace("_", ".")
-            start, end, strand = (
-                str(feature.location.start),
-                str(feature.location.end),
-                feature.location.strand,
-            )
-            start = start.replace(">", "").replace("<", "")
-            end = end.replace(">", "").replace("<", "")
-            strand_sense = "neg" if strand == -1 else ("pos" if strand == 1 else "")
-            return f">{name}__{gbk_contig.name.replace('_', '')}_{gene_counter}_{start}_{end}_{strand_sense}\n"
-
-        if nucleotide:
-
-            def write_record(gbk_contig, feature, outfile, gene_counter):
-                header = get_label_str(gbk_contig, feature)
-                sequence = str(feature.extract(gbk_contig).seq)
-                outfile.write(header)
-                outfile.write(sequence + "\n")
-                gene_counter += 1
-                return gene_counter
-
-        else:
-
-            def write_record(gbk_contig, feature, outfile, gene_counter):
-                if "translation" in feature.qualifiers:
-                    header = get_label_str(gbk_contig, feature)
-                    sequence = feature.qualifiers["translation"][0]
-                    outfile.write(header)
-                    outfile.write(sequence + "\n")
-                    gene_counter += 1
-                return gene_counter
-
         with open(output_file, "w+") as outfile:
             for gbk_contig in gbk_contigs:
                 gene_counter = 0
                 for feature in gbk_contig.features:
                     if "cds" in feature.type.lower():
-                        gene_counter = write_record(
-                            gbk_contig, feature, outfile, gene_counter
+                        gene_counter = cls.write_record(
+                            gbk_contig, feature, outfile, gene_counter, nucleotide
                         )
         return cls(output_file)
 
-    def get_label_str(self, gbk_contig, feature, gene_counter):
+    @staticmethod
+    def get_label_str(
+        gbk_contig: SeqRecord, feature: SeqFeature, gene_counter: int
+    ) -> str:
         name = feature.qualifiers["locus_tag"][0].replace("_", ".")
         start, end, strand = (
             str(feature.location.start),
@@ -440,13 +411,24 @@ class LabelledFASTA(FASTA):
         strand_sense = "neg" if strand == -1 else ("pos" if strand == 1 else "")
         return f">{name}__{gbk_contig.name.replace('_', '')}_{gene_counter}_{start}_{end}_{strand_sense}\n"
 
-    def write_record(self, gbk_contig, feature, outfile, gene_counter):
-        if "translation" in feature.qualifiers:
-            header = self.get_label_str(gbk_contig, feature)
+    @staticmethod
+    def write_record(
+        gbk_contig: SeqRecord,
+        feature: SeqFeature,
+        outfile: TextIO,
+        gene_counter: int,
+        nucleotide: bool = False,
+    ) -> int:
+        header = LabelledFASTA.get_label_str(gbk_contig, feature, gene_counter)
+        if (not nucleotide) and ("translation" in feature.qualifiers):
             sequence = feature.qualifiers["translation"][0]
-            outfile.write(header)
-            outfile.write(sequence + "\n")
-            gene_counter += 1
+        elif nucleotide:
+            sequence = str(feature.extract(gbk_contig).seq)
+        else:
+            return gene_counter
+        outfile.write(header)
+        outfile.write(sequence + "\n")
+        gene_counter += 1
         return gene_counter
 
 

--- a/pynteny/preprocessing.py
+++ b/pynteny/preprocessing.py
@@ -101,24 +101,22 @@ class FASTA:
             input_file (Path): path to input fasta file.
         """
         self._input_file = Path(input_file)
-        self._input_file_str = self._input_file.as_posix()
 
-    def set_file_path(self, new_path: Path) -> None:
+    @property
+    def file_path(self) -> Path:
         """Set new path to fasta file
 
         Args:
-            new_path (Path): path to fasta file.
-        """
-        self._input_file = Path(new_path)
-        self._input_file_str = self._input_file.as_posix()
-
-    def get_file_path(self) -> Path:
-        """get path to fasta file.
+            new_path (Path, optional): path to fasta file. Defaults to None.
 
         Returns:
             Path: path to fasta file.
         """
         return self._input_file
+
+    @file_path.setter
+    def file_path(self, new_path: Path) -> None:
+        self._input_file = Path(new_path)
 
     @classmethod
     def from_FASTA_directory(cls, input_dir: Path, merged_fasta: Path = None) -> FASTA:
@@ -194,7 +192,7 @@ class FASTA:
                 export_duplicates=export_duplicates,
             )
         if point_to_new_file:
-            self.set_file_path(output_file)
+            self.file_path = output_file
 
     def remove_corrupted_sequences(
         self,
@@ -220,7 +218,9 @@ class FASTA:
         else:
             isLegitSequence = RecordSequence.is_legit_DNA_sequence
 
-        fasta = pyfastx.Fasta(self._input_file_str, build_index=False, full_name=True)
+        fasta = pyfastx.Fasta(
+            self.file_path.as_posix(), build_index=False, full_name=True
+        )
         with open(output_file, "w+") as outfile:
             for record_name, record_seq in fasta:
                 if is_peptide and (not keep_stop_codon):
@@ -228,7 +228,7 @@ class FASTA:
                 if isLegitSequence(record_seq):
                     outfile.write(f">{record_name}\n{record_seq}\n")
         if point_to_new_file:
-            self.set_file_path(output_file)
+            self.file_path = output_file
 
     def filter_by_IDs(
         self, record_ids: list, output_file: Path = None, point_to_new_file: bool = True
@@ -254,7 +254,7 @@ class FASTA:
             )
             utils.terminal_execute(cmd_str, suppress_shell_output=True)
         if point_to_new_file:
-            self.set_file_path(output_file)
+            self.file_path = output_file
 
     def split_by_contigs(self, output_dir: Path = None) -> None:
         """Split large fasta file into several ones containing one contig each.
@@ -269,7 +269,9 @@ class FASTA:
         else:
             output_dir = Path(output_dir)
         os.makedirs(output_dir, exist_ok=True)
-        contigs = pyfastx.Fasta(self._input_file_str, build_index=False, full_name=True)
+        contigs = pyfastx.Fasta(
+            self.file_path.as_posix(), build_index=False, full_name=True
+        )
         for contig_name, seq in contigs:
             outfile = (
                 output_dir / f"{contig_name.split(' ')[0]}{self._input_file.suffix}"
@@ -293,13 +295,15 @@ class FASTA:
                 Path(self._input_file.parent)
                 / f"{self._input_file.stem}_minlength{self._input_file.suffix}"
             )
-        fasta = pyfastx.Fasta(self._input_file_str, build_index=False, full_name=True)
+        fasta = pyfastx.Fasta(
+            self.file_path.as_posix(), build_index=False, full_name=True
+        )
         with open(output_file, "w+") as outfile:
             for record_name, record_seq in fasta:
                 if len(record_seq) >= min_length:
                     outfile.write(f">{record_name}\n{record_seq}\n")
         if point_to_new_file:
-            self.set_file_path(output_file)
+            self.file_path = output_file
 
 
 class LabelledFASTA(FASTA):

--- a/pynteny/preprocessing.py
+++ b/pynteny/preprocessing.py
@@ -155,7 +155,6 @@ class FASTA:
         self,
         output_file: Path = None,
         export_duplicates: bool = False,
-        method: str = "seqkit",
         point_to_new_file: bool = True,
     ) -> None:
         """Removes duplicate entries (either by sequence or ID) from fasta.
@@ -163,7 +162,6 @@ class FASTA:
         Args:
             output_file (Path, optional): path to output fasta file. Defaults to None.
             export_duplicates (bool, optional): whether duplicated records are exported to a file. Defaults to False.
-            method (str, optional): choose method to select duplicates: 'biopython' or 'seqkit'. Defaults to 'seqkit'.
             point_to_new_file (bool, optional): whether FASTA object should point to the newly generated file. Defaults to True.
 
         Yields:
@@ -174,24 +172,11 @@ class FASTA:
                 Path(self._input_file.parent)
                 / f"{self._input_file.stem}_noduplicates{self._input_file.suffix}"
             )
-
-        if "bio" in method:
-            seen_seqs, seen_ids = set(), set()
-
-            def unique_records():
-                for record in SeqIO.parse(self._input_file, "fasta"):
-                    if (record.seq not in seen_seqs) and (record.id not in seen_ids):
-                        seen_seqs.add(record.seq)
-                        seen_ids.add(record.id)
-                        yield record
-
-            SeqIO.write(unique_records(), output_file, "fasta")
-        else:
-            wrappers.run_seqkit_nodup(
-                input_fasta=self._input_file,
-                output_fasta=output_file,
-                export_duplicates=export_duplicates,
-            )
+        wrappers.run_seqkit_nodup(
+            input_fasta=self._input_file,
+            output_fasta=output_file,
+            export_duplicates=export_duplicates,
+        )
         if point_to_new_file:
             self.file_path = output_file
 

--- a/pynteny/subcommands.py
+++ b/pynteny/subcommands.py
@@ -272,7 +272,7 @@ def run_app() -> None:
     config_path = config.get_config_path()
     logfile = str(Path(config_path.parent) / "streamlit.log")
     config.update_config("streamlit_log", logfile)
-    app_path = Path(Path(__file__).parent) / "app" / "main_page.py"
+    app_path = Path(__file__).parent / "app" / "main_page.py"
     log_str = f"--logger.level=info 2> {logfile}"
     cmd_str = (
         f"streamlit run {app_path} --browser.gatherUsageStats False --server.fileWatcherType none "

--- a/pynteny/subcommands.py
+++ b/pynteny/subcommands.py
@@ -18,19 +18,15 @@ from pynteny.utils import CommandArgs, ConfigParser, is_tar_file, terminal_execu
 from pynteny.preprocessing import Database
 
 
-def synteny_search(args) -> SyntenyHits:
-    """Search peptide database by synteny structure containing HMMs.
+def init_logger(args) -> logging.Logger:
+    """Initialize logger object
 
     Args:
-        args (argparse.ArgumentParser): arguments object.
+        args (_type_): command arguments object
 
     Returns:
-        SyntenyHits: instance of SyntenyHits.
+        logging.Logger: initialized logger object
     """
-    logger = logging.getLogger(__name__)
-    if not Path(args.data).exists():
-        logger.error("Sequence data file does not exist")
-        sys.exit(1)
     if args.logfile is None:
         args.logfile = Path(os.devnull)
     elif not Path(args.logfile.parent).exists():
@@ -40,6 +36,24 @@ def synteny_search(args) -> SyntenyHits:
         handlers=[logging.FileHandler(args.logfile), logging.StreamHandler(sys.stdout)],
         level=logging.NOTSET,
     )
+    logger = logging.getLogger(__name__)
+    return logger
+
+
+def synteny_search(args) -> SyntenyHits:
+    """Search peptide database by synteny structure containing HMMs.
+
+    Args:
+        args (argparse.ArgumentParser): arguments object.
+
+    Returns:
+        SyntenyHits: instance of SyntenyHits.
+    """
+    logger = init_logger(args)
+    if not Path(args.data).exists():
+        logger.error("Sequence data file does not exist")
+        sys.exit(1)
+
     config = ConfigParser.get_default_config()
     args.synteny_struc = SyntenyParser.reformat_synteny_structure(args.synteny_struc)
     if not SyntenyParser.is_valid_structure(args.synteny_struc):
@@ -144,16 +158,8 @@ def build_database(args) -> None:
     Args:
         args (argparse.ArgumentParser): arguments object.
     """
-    if args.logfile is None:
-        args.logfile = Path(os.devnull)
-    elif not Path(args.logfile.parent).exists():
-        Path(args.logfile.parent).mkdir(parents=True)
-    logging.basicConfig(
-        format="%(asctime)s | %(levelname)s: %(message)s",
-        handlers=[logging.FileHandler(args.logfile), logging.StreamHandler(sys.stdout)],
-        level=logging.NOTSET,
-    )
-    logger = logging.getLogger(__name__)
+    logger = init_logger(args)
+
     if args.processes is None:
         args.processes = os.cpu_count() - 1
     logger.info("Building annotated peptide database")
@@ -173,16 +179,7 @@ def parse_gene_ids(args) -> str:
         str: synteny structure where gene symbols are replaced
             by HMM names.
     """
-    if args.logfile is None:
-        args.logfile = Path(os.devnull)
-    elif not Path(args.logfile.parent).exists():
-        Path(args.logfile.parent).mkdir(parents=True)
-    logging.basicConfig(
-        format="%(asctime)s | %(levelname)s: %(message)s",
-        handlers=[logging.FileHandler(args.logfile), logging.StreamHandler(sys.stdout)],
-        level=logging.NOTSET,
-    )
-    logger = logging.getLogger(__name__)
+    logger = init_logger(args)
     config = ConfigParser.get_default_config()
     if args.hmm_meta is None:
         if not config.get_field("data_downloaded"):
@@ -211,17 +208,7 @@ def download_hmms(args) -> None:
     Args:
         args (argparse.ArgumentParser): arguments object.
     """
-    if args.logfile is None:
-        args.logfile = Path(os.devnull)
-    elif not Path(args.logfile.parent).exists():
-        Path(args.logfile.parent).mkdir(parents=True)
-
-    logging.basicConfig(
-        format="%(asctime)s | %(levelname)s: %(message)s",
-        handlers=[logging.FileHandler(args.logfile), logging.StreamHandler(sys.stdout)],
-        level=logging.NOTSET,
-    )
-    logger = logging.getLogger(__name__)
+    logger = init_logger(args)
     module_dir = Path(__file__).parent
     config = ConfigParser.get_default_config()
     if config.get_field("data_downloaded"):

--- a/pynteny/utils.py
+++ b/pynteny/utils.py
@@ -46,7 +46,7 @@ class ConfigParser:
         Returns:
             Path: path to generated config file.
         """
-        config_file = Path(Path(Path(__file__).parent).parent) / "config.json"
+        config_file = Path(__file__).parent.parent / "config.json"
         if not config_file.exists():
             config = {
                 "database_dir": "",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pynteny"
-version = "0.0.5"
+version = "0.0.6"
 description = "Synteny-aware hmm searches made easy in Python"
 license = "Apache-2.0"
 authors = ["Semidán Robaina Estévez <srobaina@ull.edu.es>"]
@@ -25,6 +25,6 @@ include = [
     "pynteny/app/assets/img/*"
 ]
 [tool.poetry.dependencies]
-python = "^3.7"
+python = "^3.8"
 [tool.poetry.scripts]
 pynteny = "pynteny.cli:main"

--- a/tests/test_database_build.py
+++ b/tests/test_database_build.py
@@ -13,7 +13,7 @@ from pynteny.api import Build
 from pynteny.preprocessing import LabelledFASTA
 
 
-this_file_dir = Path(Path(__file__).parent)
+this_file_dir = Path(__file__).parent
 
 
 class TestDatabase(unittest.TestCase):

--- a/tests/test_hmm.py
+++ b/tests/test_hmm.py
@@ -10,7 +10,7 @@ from pathlib import Path
 import pandas as pd
 from pynteny.hmm import PGAP, HMMER
 
-this_file_dir = Path(Path(__file__).parent)
+this_file_dir = Path(__file__).parent
 
 
 class TestPGAP(unittest.TestCase):

--- a/tests/test_integration_search.py
+++ b/tests/test_integration_search.py
@@ -33,9 +33,9 @@ class TestSyntenySearch(unittest.TestCase):
             )
             hmm_meta = this_file_dir / "test_data/hmm_meta.tsv"
             synhits = search.run()
-            # synhits_df = synhits.get_synteny_hits()
+            # synhits_df = synhits.hits
             synhits = synhits.add_HMM_meta_info_to_hits(hmm_meta)
-            synhits_df = synhits.get_synteny_hits()
+            synhits_df = synhits.hits
             config = Path(this_file_dir.parent) / "config.json"
             if config.exists():
                 config.unlink()

--- a/tests/test_integration_search.py
+++ b/tests/test_integration_search.py
@@ -11,7 +11,7 @@ from tempfile import TemporaryDirectory
 
 from pynteny.api import Search
 
-this_file_dir = Path(Path(__file__).parent)
+this_file_dir = Path(__file__).parent
 
 
 class TestSyntenySearch(unittest.TestCase):

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from pynteny.filter import LabelParser, SyntenyParser
 
 
-this_file_dir = Path(Path(__file__).parent)
+this_file_dir = Path(__file__).parent
 
 
 class TestLabelParser(unittest.TestCase):

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -10,7 +10,7 @@ import tempfile
 from pathlib import Path
 from pynteny.preprocessing import RecordSequence, FASTA, LabelledFASTA
 
-this_file_dir = Path(Path(__file__).parent)
+this_file_dir = Path(__file__).parent
 
 
 class TestRecordSequence(unittest.TestCase):

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -58,7 +58,7 @@ class TestFASTA(unittest.TestCase):
         with tempfile.NamedTemporaryFile() as tmp:
             fasta.remove_duplicates(output_file=Path(tmp.name))
             self.assertEqual(
-                fasta.get_file_path(),
+                fasta.file_path,
                 Path(tmp.name),
                 "Failed to remove duplicates in FASTA",
             )
@@ -68,7 +68,7 @@ class TestFASTA(unittest.TestCase):
         with tempfile.NamedTemporaryFile() as tmp:
             fasta.remove_corrupted_sequences(output_file=Path(tmp.name))
             self.assertEqual(
-                fasta.get_file_path(),
+                fasta.file_path,
                 Path(tmp.name),
                 "Failed to remove corrupted sequences in FASTA",
             )
@@ -80,7 +80,7 @@ class TestFASTA(unittest.TestCase):
                 record_ids=["b0001__U00096_0_189_255_pos"], output_file=Path(tmp.name)
             )
             self.assertEqual(
-                fasta.get_file_path(),
+                fasta.file_path,
                 Path(tmp.name),
                 "Failed to filter records by ID in FASTA",
             )
@@ -90,7 +90,7 @@ class TestFASTA(unittest.TestCase):
         with tempfile.NamedTemporaryFile() as tmp:
             fasta.filter_by_minimum_length(min_length=50, output_file=Path(tmp.name))
             self.assertEqual(
-                fasta.get_file_path(),
+                fasta.file_path,
                 Path(tmp.name),
                 "Failed to filter FASTA by length",
             )


### PR DESCRIPTION
This PR covers the following comments from Reviewer:

> 
> ### pynteny/**init**.py
> * `import *` are usually frowned upon in Python, but IMO this is ok in this case

I agree, but, anyway I modified init to explicitly import all the classes, we don't want to be frowned upon.

> ### pynteny/api.py
> * `importlib.metadata` is only available in the standard library from 3.8 and onwards (3.7 is technically allowed in 0.0.5). This is partially fixed in the `main` branch. For good measure, I would increase the minimum Python version in the `pyproject.toml` file as well, even if poetry is only used as a build backend.

Thanks, already taken care of. Now python >= 3.8.

> * The author could use a simple type hint in the `Command` class to avoid a linter warning in the `update` method:
> 
> ```python
> class Command():
>     """Parent class for Pynteny command
>     """
>     _args: CommandArgs
>     
> ```
> 

Great, thanks for catching this!

> * Empty `__init__` methods are not necessary, the smaller the code base the better!

Right! Modified.

> * There are really nice uses of the package’s metadata in `_repr_html_`  and `cite`

:)

> * I am pleased to see that arguments with `None` default value are correctly typed as `optional`

:)

> * There is no need to wrap `Path(__file__).parent` in another `Path()` in the `getTestDataPath` method since it returns a `Path` object as well. This comment applies to utils.py as well.

Right, thanks for catching this.

> 
> ### pynteny/cli.py
> * `args` is not used in the `Pynteny.app` method, so there is no need to parse it.

Thanks. It's there so one can run "pynteny app --help" from the command line. I know this is not necessary. I left it there for consistency with the other subcommands. Perhaps in future versions "pyteny app" could have proper arguments, e.g. select port.

> * I believe `getHelpStr` could be simpler by writing to an `io.StringIO` instead of a temp file.

Thanks. I'm leaving it as it is for now but will consider this suggestion in future settings.

> * f-strings without placeholder are considered code smells

Right, removed, not sure why they were there in the first place.

> * Overall, this is a really nice example of a cli with subcommands, congrats!

Thank you!

> * I saw a few unused `required` and `pynteny` assignment

Right, subcomand.download does not have `required` arguments. I removed it. As of the ìnstance `pynteny` in cli.main, is there to avoid printing of the class descriptor to the command line.

> 
> ### pynteny/filter.py
> * typo L40 `specified`

Ok

> * As far as I can tell, the `hmm_order_dict` is not needed in `SyntenyPatternFilters` init method.

Right, removed.

> * The lambda expr + map is quite difficult to read. A simpler alternative could be:
> 
> ```python
> strand_map = dict(neg=-1, pos=1) # could be set as a module-wide constant
> self.strand_order_pattern = [strand_map.get(strand, 0) for strand in parsed_structure["strands"]]
> ```

While I appreciate the suggestion, I don't feel like it would improve the readability of the code in this case. With your suggestion, the reader would have to jump to the beginning of the file to understand that "-1" means "neg" and "1", "pos". I personally think that the lambda expression is closer to how one would describe the functionality in plain English.

> * `contains_hmm_pattern`, `contains_distance_pattern`, and `contains_strand_pattern` could use Python’s idioms and return boolean values instead of integers, this is not an issue with their use in pandas rolling method. Boolean values can be aggregated numerically in pandas. This would simplify those methods. In `contains_strand_pattern`, there is a `True` equality comparison.

Thanks for the suggestion. I have removed the equality to True as it is not necessary.

> * Using `inplace=True` in pandas operation is not recommended and could be deprecated: [API/DEPR: Deprecate inplace parameter pandas-dev/pandas#16529](https://github.com/pandas-dev/pandas/issues/16529).

Alright, changed.


> * The author could use the `size` method instead of a filter with a lambda in `getAllHMMhits`, but this is a matter of preference.

Thanks for the suggestion. I'll leave the filter for now. I feel it is somewhat more idiomatic. 


> * There again, preferences, but the loop in `filterHitsBySyntenyStructure` could be made on a pandas’ groupby object. This is not a prominent feature, but one may do the following:
> 
> ```python
> for group_key, group_df in df.groupby(key):
>     pass
> ```

Awesome! Will leave it as it is (lack of time) but will definitely consider it in future occurrences.

> * the form `len(contig_hits.hmm.unique())` could be simplified to `contig_hits.hmm.nunique()`

Haha did not know this method existed. Convenient. Thanks

> * Using `iterrows` is quite inefficient if one only need to loop over the index. The author may use `for i in matched_rows.index`

Right, changed, thanks!

> * Idiomatic Python does not usually use getter methods such as `getSyntenyHits`, a public attribute would work just fine.

Thanks for the suggestion, but if I understand correctly, then the value of the attribute could be modified outside the method, and I want to prevent that. Since getter methods are not pythonic, I'll rename it "hits" and decorate it with @property.

> * I have not profiled the code to see if there is a performance bottleneck there, but I would use `itertuples` instead of `iterrows` in `addHMMmetaInfoToHits`. `itertuples` is much faster if you need to iterate over data frames one row at a time

Thanks for the suggestion. Definitely will try it out. It's a pitty that the code gets uglier this way. Don't consider myself a python expert, but it seems to me that the python community is having some internal conflicts between efficiency and code readability (pythonicity).

> * I suggest using `isinstance` rather than type equality in `filterFASTAbySyntenyStructure`. `isinstance` is a more robust (and marginally faster) solution because it allows nominal subtyping: any subtype of `str` or `list` would pass the test conditions. Using `isinstance` is therefore considered more pythonic than type equality.

Thanks, changed!

> 
> ### pynteny/hmm.py
> * Nice use of properties
> * Since the author is using pathlib, they might use `/` or `Path.joinpath` instead of `os.path.join`

Makes sense, changed!

> * The author may use the `usecols` argument for `pd.read_csv`

Thanks, changed.


> * Why is the`try-except` block needed in `getHMMnamesByGeneSymbol`? (+ bare except is considered a code smell). The code would work without this. The same goes for `getHMMgeneID`, with a little twist to return `None`, and for `getMetaInfoForHMM`

Thanks, changed.
> 
> ### pynteny/parser.py

> * There are too many statements in the `try-except` block in `LabelParser.parse`. I do not know what could be failing (a `split`, an int cast?), and the exception caught is too broad. Tip: I suggest extracting `meta.split("_")` in a variable since it appears in four lines in a row

Alright. I removed try-except and added a logger.error to check label format.

> * Typing tuples is quite unintuitive: `tuple[str]` means “a tuple of exactly one str.” This means that  `splitStrandFromLocus` is incorrectly typed

I see. Thanks for catching this. I assumed that tuple styling would be similar to list. But I see now that's not the case. I'll change it to `tuple[str, ...]` since this appears to be the equivalent of `list[str]`.

> ### pynteny/preprocessing.py
> * In FASTA class, we could replace the getter/setter with a property, which is more “pythonic”. Moreover, we could also make `_input_file_str` a read-only property.

Created a property and removed `_input_file_str`, it's just fine to call `.as_posix`when required. Thanks.


> * `number_prodigal_record_fields` could be a global constant

I could make it a global constant. However, defining the constant at the beginning of the module implies that the reader would have to go up to see its value and then down again to the function. Since this constant is only used by one class method, I think that making it global is not necessary.



> * If pynteny targets python ≥3.10 as the main branch suggests, then it may use https://docs.python.org/3/whatsnew/3.10.html#parenthesized-context-managers in `GeneAnnotator`

That was the original idea, but now Pynteny targets python >= 3.8. That's a pity because parenthesized context managers look cool.

> ### pynteny/subcommands.py
> * There is a piece of code duplicated four times. The following could be extracted in its own function.
> 
> ```python
> if args.logfile is None:
>     args.logfile = Path(os.devnull)
> elif not Path(args.logfile.parent).exists():
>     Path(args.logfile.parent).mkdir(parents=True)
> logging.basicConfig(format='%(asctime)s | %(levelname)s: %(message)s',
>                     handlers=[
>                         logging.FileHandler(args.logfile),
>                         logging.StreamHandler(sys.stdout)
>                         ],
>                     level=logging.NOTSET)
> logger = logging.getLogger(__name__)
> ```
> 
> In addition, this would limit the complexity of `synteny_search`

That makes sense. I have converted this block of code into a function.