### PR TITLE
PyOpenSci REVIEW - remove default location for PGAP download

### DIFF
--- a/src/pynteny/cli.py
+++ b/src/pynteny/cli.py
@@ -458,10 +458,10 @@ class SubcommandParser:
         )
 
         optional = parser._action_groups.pop()
-        # required = parser.add_argument_group("required arguments")
+        required = parser.add_argument_group("required arguments")
         parser._action_groups.append(optional)
 
-        optional.add_argument(
+        required.add_argument(
             "-o",
             "--outdir",
             dest="outdir",
@@ -470,8 +470,10 @@ class SubcommandParser:
             required=False,
             default=None,
             help=(
-                "path to directory where to download HMM database.\n"
-                "Defaults to pynteny installation directory."
+                "path to directory where to download HMM database. \n"
+                "Note, if database is relocated after download, Pynteny won't be able to find it automatically, \n"
+                "You can either: delete and download again in the new location or manually indicate database and \n"
+                "meta file location in Pynteny search."
             ),
         )
         optional.add_argument(

--- a/src/pynteny/subcommands.py
+++ b/src/pynteny/subcommands.py
@@ -221,7 +221,8 @@ def download_hmms(args) -> None:
         logger.info("PGAP database already downloaded. Skipping download")
         sys.exit(1)
     if args.outdir is None:
-        download_dir = module_dir / "data"
+        logger.error("Please, provide directory in which to download PGAP database.")
+        sys.exit(1)
     else:
         download_dir = Path(args.outdir).absolute()
     if not download_dir.exists():


### PR DESCRIPTION
As part of the [PyOpenSci](https://github.com/pyOpenSci/software-submission/issues/67) review, this PR removes the default location where to download the PGAP database as it is hard to remove the database after uninstall (see previous [PR](https://github.com/Robaina/Pynteny/pull/51)).