### PR TITLE
Chore/add qoc config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+on: push
+jobs:
+  quality:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.8"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install ruff black
+      # Include `--format=github` to enable automatic inline annotations.
+      - name: Check linters
+        run: ruff --format=github .
+      - name: Check format
+        run: black --check .

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,12 @@
+default_stages: [ commit, push ]
+fail_fast: false
+repos:
+  - repo: https://github.com/psf/black
+    rev: 23.1.0
+    hooks:
+      - id: black
+        language_version: python3
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: 'v0.0.240'
+    hooks:
+      - id: ruff

--- a/envs/pynteny-dev.yml
+++ b/envs/pynteny-dev.yml
@@ -8,6 +8,7 @@ dependencies:
   - python >= 3.8
   - poetry >= 1.3
   - coverage
+  - black
   - pip
   - hmmer >= 3.3
   - prodigal >= 2.6
@@ -16,7 +17,7 @@ dependencies:
   - numpy
   - pandas
   - psutil >= 5.9
-  - python-wget 
+  - python-wget
   - streamlit=1.16
   - streamlit-aggrid
   - pip:
@@ -25,3 +26,4 @@ dependencies:
     - pymdown-extensions
     - mkdocs-jupyter
     - mkdocstrings[python]
+    - ruff

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,3 +32,21 @@ include = [
 python = "^3.8"
 [tool.poetry.scripts]
 pynteny = "pynteny.cli:main"
+
+[tool.ruff]
+select = [
+    "E", # pycodestyle errors
+    "W", # pycodestyle warnings
+    "F", # pyflakes
+    "I", # isort
+]
+ignore = [
+    "E501", # line too long, handled by black
+    "B008", # do not perform function calls in argument defaults
+    "C901", # mccabe complexity
+    "E999", # match statement is not yet supported
+    "W605", # ASCII art, verbatim text
+]
+
+[tool.ruff.isort]
+known-first-party = ["pynteny"]

--- a/src/pynteny/__init__.py
+++ b/src/pynteny/__init__.py
@@ -1,2 +1,4 @@
-from pynteny.api import Command, Search, Build, Download
+from pynteny.api import Build, Command, Download, Search
 from pynteny.cli import main
+
+__all__ = ("main", "Command", "Search", "Build", "Download")

--- a/src/pynteny/api.py
+++ b/src/pynteny/api.py
@@ -5,18 +5,18 @@
 Classes to facilitate usage within Python scripts / Notebooks
 """
 
-from pathlib import Path
 from importlib import metadata
+from pathlib import Path
 
-from pynteny.utils import CommandArgs
 from pynteny.filter import SyntenyHits
 from pynteny.subcommands import (
-    synteny_search,
     build_database,
     download_hmms,
-    parse_gene_ids,
     get_citation,
+    parse_gene_ids,
+    synteny_search,
 )
+from pynteny.utils import CommandArgs
 
 meta = metadata.metadata("pynteny")
 __version__ = meta["Version"]

--- a/src/pynteny/app/callbacks.py
+++ b/src/pynteny/app/callbacks.py
@@ -5,12 +5,12 @@
 
 import shutil
 from pathlib import Path
+
 import streamlit as st
 
 import pynteny.app.filemanager as filemanager
-from pynteny.subcommands import synteny_search, build_database, download_hmms
+from pynteny.subcommands import build_database, download_hmms, synteny_search
 from pynteny.utils import ConfigParser
-
 
 parent_dir = Path(__file__).parent
 

--- a/src/pynteny/app/components.py
+++ b/src/pynteny/app/components.py
@@ -3,10 +3,9 @@ from importlib import metadata
 
 import streamlit as st
 
-from pynteny.app.helpers import plot_dataframe
 import pynteny.app.callbacks as callbacks
 import pynteny.app.filemanager as filemanager
-
+from pynteny.app.helpers import plot_dataframe
 
 meta = metadata.metadata("pynteny")
 __version__ = meta["Version"]
@@ -73,7 +72,7 @@ def show_sidebar():
             )
         with col2:
             st.markdown(("Output log:"))
-            output_log = st.select_slider(
+            st.select_slider(
                 "",
                 options=["No", "Yes"],
                 value="Yes",

--- a/src/pynteny/app/components.py
+++ b/src/pynteny/app/components.py
@@ -14,7 +14,6 @@ __author__ = meta["Author"]
 
 
 def show_sidebar():
-
     st.sidebar.image(
         st.session_state.sidebar_icon,
         use_column_width=True,
@@ -53,7 +52,6 @@ def show_sidebar():
             )
 
     with st.sidebar.expander("Advanced parameters:", expanded=False):
-
         st.markdown("Select custom HMM database")
         col1, col2 = st.columns([1, 1])
         with col1:
@@ -91,7 +89,6 @@ def show_sidebar():
 
 
 def show_mainpage():
-
     st.title("Pynteny — Synteny-aware HMM searches made easy")
 
     with st.expander("Select sequence data", expanded=False):

--- a/src/pynteny/app/filemanager.py
+++ b/src/pynteny/app/filemanager.py
@@ -3,12 +3,11 @@
 
 """Tools to handle files in Streamlit App"""
 
-from pathlib import Path
-
 import tkinter as tk
+from pathlib import Path
 from tkinter import filedialog
-import streamlit as st
 
+import streamlit as st
 
 parent_dir = Path(__file__).parent
 
@@ -56,7 +55,7 @@ def open_file_explorer() -> Path:
     root.withdraw()
     try:
         selected_path = Path(filedialog.askopenfilename())
-    except:
+    except Exception:
         selected_path = None
     root.destroy()
     return selected_path
@@ -71,7 +70,7 @@ def open_directory_explorer() -> Path:
     root.withdraw()
     try:
         selected_dir = Path(filedialog.askdirectory(master=root))
-    except:
+    except Exception:
         selected_dir = None
     root.destroy()
     return selected_dir

--- a/src/pynteny/app/helpers.py
+++ b/src/pynteny/app/helpers.py
@@ -7,7 +7,6 @@ import pandas as pd
 import streamlit as st
 from st_aggrid import AgGrid, GridOptionsBuilder
 
-
 parent_dir = Path(__file__).parent
 
 

--- a/src/pynteny/app/main_page.py
+++ b/src/pynteny/app/main_page.py
@@ -4,10 +4,9 @@ from pathlib import Path
 import streamlit as st
 from PIL import Image
 
-from pynteny.utils import CommandArgs
+from pynteny.app.components import show_mainpage, show_sidebar
 from pynteny.app.helpers import set_example
-from pynteny.app.components import show_sidebar, show_mainpage
-
+from pynteny.utils import CommandArgs
 
 parent_dir = Path(__file__).parent
 meta = metadata.metadata("pynteny")

--- a/src/pynteny/cli.py
+++ b/src/pynteny/cli.py
@@ -2,16 +2,16 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import annotations
-import sys
-import random
-import tempfile
+
 import argparse
+import random
+import sys
+import tempfile
 from importlib import metadata
 from pathlib import Path
 
 import pynteny.subcommands as sub
 from pynteny.utils import ConfigParser
-
 
 meta = metadata.metadata("pynteny")
 __version__ = meta["Version"]
@@ -122,7 +122,7 @@ class Pynteny:
     def app(self):
         """Run pynteny app through Streamlit"""
         parser = SubcommandParser.app()
-        args = parser.parse_args(self._subcommand_args)
+        parser.parse_args(self._subcommand_args)
         sub.run_app()
 
     def cite(self):
@@ -518,7 +518,7 @@ class SubcommandParser:
             formatter_class=argparse.RawTextHelpFormatter,
         )
         optional = parser._action_groups.pop()
-        required = parser.add_argument_group("required arguments")
+        parser.add_argument_group("required arguments")
         parser._action_groups.append(optional)
         return parser
 
@@ -536,14 +536,14 @@ class SubcommandParser:
             formatter_class=argparse.RawTextHelpFormatter,
         )
         optional = parser._action_groups.pop()
-        required = parser.add_argument_group("required arguments")
+        parser.add_argument_group("required arguments")
         parser._action_groups.append(optional)
         return parser
 
 
 def main():
     subcommand, subcommand_args = sys.argv[1:2], sys.argv[2:]
-    pynteny = Pynteny(subcommand, subcommand_args)
+    Pynteny(subcommand, subcommand_args)
 
 
 if __name__ == "__main__":

--- a/src/pynteny/filter.py
+++ b/src/pynteny/filter.py
@@ -6,17 +6,18 @@ Tools to filter HMM hits by synteny structure
 """
 
 from __future__ import annotations
+
+import logging
 import os
 import sys
-import logging
 from pathlib import Path
 
 import pandas as pd
 
-from pynteny.preprocessing import FASTA
-from pynteny.hmm import HMMER, PGAP
 import pynteny.parsers.labelparser as labelparser
 import pynteny.parsers.syntenyparser as syntenyparser
+from pynteny.hmm import HMMER, PGAP
+from pynteny.preprocessing import FASTA
 
 logger = logging.getLogger(__name__)
 

--- a/src/pynteny/filter.py
+++ b/src/pynteny/filter.py
@@ -291,7 +291,6 @@ class SyntenyHMMfilter:
             }
 
             if contig_hits.hmm.nunique() >= self._n_hmm_groups:
-
                 hmm_match = contig_hits.hmm_code.rolling(
                     window=self._n_hmm_groups
                 ).apply(filters.contains_hmm_pattern)

--- a/src/pynteny/hmm.py
+++ b/src/pynteny/hmm.py
@@ -6,19 +6,19 @@ Tools to parse Hmmer output and PGAP (HMM) database
 """
 
 from __future__ import annotations
-import os
-import sys
-import shutil
+
 import logging
-from pathlib import Path
+import os
+import shutil
+import sys
 from collections import defaultdict
+from pathlib import Path
 
 import pandas as pd
 from Bio import SearchIO
 
 import pynteny.wrappers as wrappers
-from pynteny.utils import is_tar_file, extract_tar_file, flatten_directory, list_tar_dir
-
+from pynteny.utils import extract_tar_file, flatten_directory, is_tar_file, list_tar_dir
 
 logger = logging.getLogger(__name__)
 

--- a/src/pynteny/parsers/labelparser.py
+++ b/src/pynteny/parsers/labelparser.py
@@ -6,10 +6,10 @@ Tools to parse record labels to extract coded info
 """
 
 from __future__ import annotations
+
 import logging
 
 import pandas as pd
-
 
 logger = logging.getLogger(__name__)
 

--- a/src/pynteny/parsers/syntenyparser.py
+++ b/src/pynteny/parsers/syntenyparser.py
@@ -6,11 +6,10 @@ Tools to parse synteny structure strings
 """
 
 from __future__ import annotations
-import sys
-import logging
-from pathlib import Path
 
-import pandas as pd
+import logging
+import sys
+from pathlib import Path
 
 from pynteny.hmm import PGAP
 from pynteny.utils import is_right_list_nested_type

--- a/src/pynteny/preprocessing.py
+++ b/src/pynteny/preprocessing.py
@@ -10,15 +10,16 @@ Tools to preprocess sequence databases
 """
 
 from __future__ import annotations
-from typing import TextIO
-import sys
-import os
+
 import logging
+import os
+import sys
 import tempfile
 from pathlib import Path
+from typing import TextIO
 
-from Bio import SeqIO, SeqRecord, SeqFeature
 import pyfastx
+from Bio import SeqFeature, SeqIO, SeqRecord
 
 import pynteny.utils as utils
 import pynteny.wrappers as wrappers
@@ -141,7 +142,7 @@ class FASTA:
         """
         if output_file is None:
             output_file = input_dir / "merged.fasta"
-        logger.info(f"Merging FASTA files in input directory")
+        logger.info("Merging FASTA files in input directory")
         # cmd_str = f'awk 1 * > {output_file}'
         # # cmd_str = "find . -maxdepth 1 -type f --exec cat {} + > " + f"{output_file}"
         cmd_str = f"printf '%s\\0' * | xargs -0 cat > {output_file}"

--- a/src/pynteny/subcommands.py
+++ b/src/pynteny/subcommands.py
@@ -5,25 +5,25 @@
 Functions containing CLI subcommands
 """
 
-import os
-import sys
-import shutil
 import logging
+import os
+import shutil
+import sys
+from argparse import ArgumentParser
 from pathlib import Path
 from typing import Union
-from argparse import ArgumentParser
 
+import pynteny.parsers.syntenyparser as syntenyparser
 from pynteny.filter import SyntenyHits, filter_FASTA_by_synteny_structure
 from pynteny.hmm import PGAP
-import pynteny.parsers.syntenyparser as syntenyparser
+from pynteny.preprocessing import Database
 from pynteny.utils import (
     CommandArgs,
     ConfigParser,
+    download_file,
     is_tar_file,
     terminal_execute,
-    download_file,
 )
-from pynteny.preprocessing import Database
 
 
 def init_logger(args: Union[CommandArgs, ArgumentParser]) -> logging.Logger:
@@ -217,7 +217,7 @@ def download_hmms(args: Union[CommandArgs, ArgumentParser]) -> None:
         args (Union[CommandArgs, ArgumentParser]): arguments object.
     """
     logger = init_logger(args)
-    module_dir = Path(__file__).parent
+    Path(__file__).parent
     config = ConfigParser.get_default_config()
     if (config.get_field("data_downloaded")) and (not args.force):
         logger.info("PGAP database already downloaded. Skipping download")
@@ -245,7 +245,7 @@ def download_hmms(args: Union[CommandArgs, ArgumentParser]) -> None:
         config.update_config("data_downloaded", True)
         config.update_config("PGAP_database", PGAP_file.as_posix())
         config.update_config("PGAP_meta_file", meta_file.as_posix())
-    except Exception as e:
+    except Exception:
         logger.exception(
             "Failed to download PGAP database. Please check your internet connection."
         )

--- a/src/pynteny/subcommands.py
+++ b/src/pynteny/subcommands.py
@@ -217,7 +217,6 @@ def download_hmms(args: Union[CommandArgs, ArgumentParser]) -> None:
         args (Union[CommandArgs, ArgumentParser]): arguments object.
     """
     logger = init_logger(args)
-    Path(__file__).parent
     config = ConfigParser.get_default_config()
     if (config.get_field("data_downloaded")) and (not args.force):
         logger.info("PGAP database already downloaded. Skipping download")

--- a/src/pynteny/utils.py
+++ b/src/pynteny/utils.py
@@ -6,17 +6,19 @@ Functions and classes for general purposes
 """
 
 from __future__ import annotations
-import os
-import sys
-import wget
+
+import json
 import logging
+import os
 import shutil
 import subprocess
+import sys
 import tarfile
-import json
-from pathlib import Path
 from functools import partial
 from multiprocessing import Pool
+from pathlib import Path
+
+import wget
 
 logger = logging.getLogger(__name__)
 

--- a/src/pynteny/wrappers.py
+++ b/src/pynteny/wrappers.py
@@ -8,7 +8,7 @@ Simple CLI wrappers to several tools
 import os
 from pathlib import Path
 
-from pynteny.utils import terminal_execute, set_default_output_path
+from pynteny.utils import set_default_output_path, terminal_execute
 
 
 def run_seqkit_nodup(

--- a/tests/test_database_build.py
+++ b/tests/test_database_build.py
@@ -5,13 +5,13 @@
 Unit tests for class Database
 """
 
-import unittest
 import tempfile
+import unittest
 from pathlib import Path
-from pynteny.subcommands import Database
+
 from pynteny.api import Build
 from pynteny.preprocessing import LabelledFASTA
-
+from pynteny.subcommands import Database
 
 this_file_dir = Path(__file__).parent
 
@@ -30,7 +30,7 @@ class TestDatabase(unittest.TestCase):
 
     def test_build(self):
         with tempfile.NamedTemporaryFile() as outfile:
-            labelled_database = Build(
+            Build(
                 data=Path(this_file_dir / "test_data/test_assembly"),
                 outfile=outfile.name,
                 logfile=None,

--- a/tests/test_hmm.py
+++ b/tests/test_hmm.py
@@ -4,11 +4,13 @@
 """
 Unit tests for the filter module
 """
-import unittest
 import tempfile
+import unittest
 from pathlib import Path
+
 import pandas as pd
-from pynteny.hmm import PGAP, HMMER
+
+from pynteny.hmm import HMMER, PGAP
 
 this_file_dir = Path(__file__).parent
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -11,7 +11,6 @@ from pathlib import Path
 import pynteny.parsers.labelparser as labelparser
 import pynteny.parsers.syntenyparser as syntenyparser
 
-
 this_file_dir = Path(__file__).parent
 
 

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -5,9 +5,10 @@
 Unit tests for the preprocessing module
 """
 
-import unittest
 import tempfile
+import unittest
 from pathlib import Path
+
 from pynteny.preprocessing import (
     FASTA,
     LabelledFASTA,


### PR DESCRIPTION
This PR adds a few quality of code tools to help with long-term maintenance.

- ruff configuration: The provided configuration enables flake8 & isort rules. Here is the transcript of the run that changed files with those rules.
<details>
<summary>
`ruff .`
</summary>
<pre>
src/pynteny/__init__.py:1:1: I001 Import block is un-sorted or un-formatted
src/pynteny/api.py:8:1: I001 Import block is un-sorted or un-formatted
src/pynteny/app/callbacks.py:6:1: I001 Import block is un-sorted or un-formatted
src/pynteny/app/components.py:1:1: I001 Import block is un-sorted or un-formatted
src/pynteny/app/components.py:76:13: F841 Local variable `output_log` is assigned to but never used
src/pynteny/app/filemanager.py:6:1: I001 Import block is un-sorted or un-formatted
src/pynteny/app/filemanager.py:59:5: E722 Do not use bare `except`
src/pynteny/app/filemanager.py:74:5: E722 Do not use bare `except`
src/pynteny/app/helpers.py:4:1: I001 Import block is un-sorted or un-formatted
src/pynteny/app/main_page.py:1:1: I001 Import block is un-sorted or un-formatted
src/pynteny/cli.py:4:1: I001 Import block is un-sorted or un-formatted
src/pynteny/cli.py:125:9: F841 Local variable `args` is assigned to but never used
src/pynteny/cli.py:521:9: F841 Local variable `required` is assigned to but never used
src/pynteny/cli.py:539:9: F841 Local variable `required` is assigned to but never used
src/pynteny/cli.py:546:5: F841 Local variable `pynteny` is assigned to but never used
src/pynteny/filter.py:8:1: I001 Import block is un-sorted or un-formatted
src/pynteny/hmm.py:8:1: I001 Import block is un-sorted or un-formatted
src/pynteny/parsers/labelparser.py:8:1: I001 Import block is un-sorted or un-formatted
src/pynteny/parsers/syntenyparser.py:8:1: I001 Import block is un-sorted or un-formatted
src/pynteny/parsers/syntenyparser.py:13:8: F401 `pandas` imported but unused
src/pynteny/preprocessing.py:12:1: I001 Import block is un-sorted or un-formatted
src/pynteny/preprocessing.py:144:21: F541 f-string without any placeholders
src/pynteny/subcommands.py:8:1: I001 Import block is un-sorted or un-formatted
src/pynteny/subcommands.py:220:5: F841 Local variable `module_dir` is assigned to but never used
src/pynteny/subcommands.py:248:25: F841 Local variable `e` is assigned to but never used
src/pynteny/utils.py:8:1: I001 Import block is un-sorted or un-formatted
src/pynteny/wrappers.py:8:1: I001 Import block is un-sorted or un-formatted
tests/test_database_build.py:8:1: I001 Import block is un-sorted or un-formatted
tests/test_database_build.py:33:13: F841 Local variable `labelled_database` is assigned to but never used
tests/test_hmm.py:7:1: I001 Import block is un-sorted or un-formatted
tests/test_parser.py:8:1: I001 Import block is un-sorted or un-formatted
tests/test_preprocessing.py:8:1: I001 Import block is un-sorted or un-formatted
Found 32 errors.
30 potentially fixable with the --fix option.

</pre>
</details>

The two "bare except" errors are silenced using `Exception`. This is only a bit better than bare except (I will not bore you with the details, but bare except catches stuff like SIGINT signal with Ctrl + C, whereas `Exception` is the superclass of all user-defined exceptions)

- pre-commit configuration. Pre-commit allows "hooks" to run before committing files. I propose the two following hooks to get started: black & ruff.
- **To be done**: CI checks  