### PR TITLE
Add PyPI Trusted Publishing workflow; bump to 1.2.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,52 @@
+name: publish
+
+# Build and publish Pynteny to PyPI via Trusted Publishing (OIDC) whenever a
+# GitHub Release is published. No API tokens or secrets are stored: PyPI must
+# have a "trusted publisher" configured for this repository, workflow
+# (publish.yml) and environment (pypi).
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+
+  build:
+    name: Build distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Build sdist and wheel
+        run: |
+          python -m pip install --upgrade pip build
+          python -m build
+      - name: Check distribution metadata
+        run: |
+          python -m pip install twine
+          twine check dist/*
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    name: Publish to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/project/pynteny/
+    permissions:
+      id-token: write  # required for Trusted Publishing (OIDC)
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pynteny"
-version = "1.1.2"
+version = "1.2.0"
 description = "Synteny-aware hmm searches made easy in Python"
 license = "Apache-2.0"
 authors = ["Semidán Robaina Estévez <srobaina@ull.edu.es>"]


### PR DESCRIPTION
Sets up automated publishing of Pynteny to PyPI via **Trusted Publishing** (OIDC — no API tokens or secrets stored), and bumps the version for the first pip-only release.

## Changes
- **`.github/workflows/publish.yml`**: on every published GitHub Release, builds the sdist + wheel, runs `twine check`, and uploads to PyPI using `pypa/gh-action-pypi-publish` with OIDC. Uses the `pypi` environment and `id-token: write`.
- **Version `1.1.2` → `1.2.0`** (first conda-free release; `v1.1.2` was already tagged for the old conda build).

## Verified locally
`python -m build` + `twine check` both pass; the wheel bundles `config.json`, installs in a clean venv, reports `1.2.0`, and `pynteny --help` works.

## Required one-time setup on PyPI (before the first release)
Add a **pending publisher** at https://pypi.org/manage/account/publishing/ :
- PyPI project name: `pynteny`
- Owner: `Robaina`
- Repository: `Pynteny`
- Workflow filename: `publish.yml`
- Environment name: `pypi`

After this PR is merged and the publisher is configured, publishing is triggered by creating a GitHub Release tagged `v1.2.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)