### PR TITLE
docs: Pynteny is on PyPI — lead with pip install pynteny

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 ![license](https://img.shields.io/github/license/Robaina/Pynteny)
 ![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-v2.0%20adopted-ff69b4)
 
+[![PyPI version](https://img.shields.io/pypi/v/pynteny?logo=pypi&style=flat-square)](https://pypi.org/project/pynteny/)
 [![GitHub release](https://img.shields.io/github/release/Robaina/Pynteny.svg)](https://GitHub.com/Robaina/Pynteny/releases/)
 
 ![python](https://img.shields.io/badge/Python-3.9%20|%203.12-blue)
@@ -36,16 +37,16 @@ binaries). All dependencies, including the HMMER and Prodigal engines, are
 provided by the pip packages [pyhmmer](https://github.com/althonos/pyhmmer) and
 [pyrodigal](https://github.com/althonos/pyrodigal).
 
-Install the latest development version directly from GitHub:
-
-```bash
-pip install git+https://github.com/Robaina/Pynteny.git
-```
-
-Once released on PyPI, Pynteny will also be installable with:
+Install with pip:
 
 ```bash
 pip install pynteny
+```
+
+Or install the latest development version directly from GitHub:
+
+```bash
+pip install git+https://github.com/Robaina/Pynteny.git
 ```
 
 Check that the installation worked fine:

--- a/docs/examples/example_api_colab.ipynb
+++ b/docs/examples/example_api_colab.ipynb
@@ -45,7 +45,7 @@
         "try:\n",
         "  import google.colab\n",
         "  # Pynteny is a pure-pip package (no conda / external binaries required).\n",
-        "  !pip install -q git+https://github.com/Robaina/Pynteny.git\n",
+        "  !pip install -q pynteny\n",
         "  # Grab the bundled test data used throughout this example.\n",
         "  !git clone -q https://github.com/Robaina/Pynteny.git\n",
         "  !cp -r Pynteny/tests/ . && rm -rf Pynteny\n",

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,16 +18,16 @@ binaries). The HMMER and Prodigal engines are provided by the pip packages
 [pyhmmer](https://github.com/althonos/pyhmmer) and
 [pyrodigal](https://github.com/althonos/pyrodigal).
 
-Install the latest development version directly from GitHub:
-
-```bash
-pip install git+https://github.com/Robaina/Pynteny.git
-```
-
-Once released on PyPI, Pynteny will also be installable with:
+Install with pip:
 
 ```bash
 pip install pynteny
+```
+
+Or install the latest development version directly from GitHub:
+
+```bash
+pip install git+https://github.com/Robaina/Pynteny.git
 ```
 
 Check that installation worked fine:


### PR DESCRIPTION
Pynteny `v1.2.0` is now live on PyPI, so this restores `pip install pynteny` as the primary install instruction.

- Re-add the PyPI version badge to the README.
- `pip install pynteny` is now the primary command in README and docs/index.md; the GitHub install is kept as the "latest development version" option.
- The Colab example installs from PyPI again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)