### PR TITLE
Release 1.3.0

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -7,7 +7,7 @@ authors:
     affiliation: "Department of Microbiology. University of La Laguna. Spain"
     email: "srobaina@ull.edu.es"
 title: "Pynteny: synteny-aware hmm searches made easy"
-version: 1.0.0
+version: 1.3.0
 doi: 10.5281/zenodo.7696204
-date-released: 2023-03-03
+date-released: 2026-06-19
 url: "https://github.com/Robaina/Pynteny"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pynteny"
-version = "1.2.0"
+version = "1.3.0"
 description = "Synteny-aware hmm searches made easy in Python"
 license = "Apache-2.0"
 authors = ["Semidán Robaina Estévez <srobaina@ull.edu.es>"]


### PR DESCRIPTION
Release **1.3.0** (minor).

## What's in it
- Bumps \`pyproject.toml\` version \`1.2.0\` → \`1.3.0\`.
- Updates \`CITATION.cff\` software version → 1.3.0 and date-released → 2026-06-19.

The headline feature, the opt-in \`--best_hmm_wins\` flag (keep only the highest-scoring HMM per peptide before matching the synteny structure; fixes paralog cross-hits dropping syntenic blocks, #96), already landed on \`main\` via #103. This PR just cuts the release.

Built locally: \`pynteny-1.3.0\` sdist + wheel pass \`twine check\`.

Publishing the GitHub Release (after merge) triggers the Trusted-Publishing workflow → PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)